### PR TITLE
Build Bulma from submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,12 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: zola@0.19.2
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Compile SASS with Dart Sass
+        run: npx --yes sass sass/style.scss static/style.css --style=compressed --no-source-map
       - name: Build site
         run: zola build
       - name: Upload site to GitHub Pages

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -18,6 +18,13 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: zola@0.19.2
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Compile SASS with Dart Sass
+        run: npx --yes sass sass/style.scss static/style.css --style=compressed --no-source-map
 
       - name: Check and build site
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "sass/_vendor/bulma"]
-	path = vendor/bulma
-	url = git@github.com:jgthms/bulma.git
+	path = sass/_vendor/bulma
+	url = https://github.com/jgthms/bulma.git

--- a/README.md
+++ b/README.md
@@ -3,16 +3,35 @@
 Main website for TouhouFest
 
 ## Building
-This website uses the static website generator [Zola](https://www.getzola.org/).
+This website uses the static website generator [Zola](https://www.getzola.org/) and builds our SASS framework dependencies directly from git submodules.
 
-Build a static output:
+### Cloning & Submodule Setup
+When cloning or checking out this repository, you **must include submodules** so the SASS stylesheets (`sass/_vendor/bulma`) compile properly:
 
 ```sh
-zola build
+# Clone with submodules right from the start:
+git clone --recurse-submodules https://github.com/touhoufest/touhoufest.org.git
+
+# Or if you already cloned the repository without submodules, initialize them:
+git submodule update --init --recursive
 ```
 
-To start a live-reload development session:
+### Local Development & Live-Reload
+Because Bulma v1.0.4 uses modern Dart Sass modules (`@use`/`@forward`) that exceed Zola's internal `libsass` engine, we use Dart Sass to compile `sass/style.scss` into `static/style.css`.
+
+To start a local development server with **automatic live-reload and real-time SASS recompilation**:
 
 ```sh
-zola serve
+npm install
+npm run dev
+# (Runs both `sass --watch` and `zola serve` concurrently)
+```
+
+### Static Production Build
+To compile the SASS stylesheet and generate the static HTML output into `public/`:
+
+```sh
+npm run build
+# Or manually:
+# npx --yes sass sass/style.scss static/style.css --style=compressed --no-source-map && zola build
 ```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "touhoufest.org",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Main website for TouhouFest (Zola + Custom Bulma v1 SASS build)",
+  "scripts": {
+    "dev": "npx --yes concurrently \"sass --watch sass/style.scss static/style.css\" \"zola serve\"",
+    "start": "npm run dev",
+    "build:css": "sass sass/style.scss static/style.css --style=compressed --no-source-map",
+    "watch:css": "sass --watch sass/style.scss static/style.css",
+    "build": "npm run build:css && zola build"
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.2",
+    "sass": "^1.83.0"
+  }
+}

--- a/sass/_bulma-custom.scss
+++ b/sass/_bulma-custom.scss
@@ -1,0 +1,50 @@
+// =============================================================================
+// Custom Bulma v1 SASS Build (Selective Imports)
+// Strips out unused components (breadcrumb, dropdown, level, media, menu,
+// message, pagination, panel, tabs) to produce a lean, fast stylesheet.
+// =============================================================================
+
+@forward "_vendor/bulma/sass/utilities";
+@forward "_vendor/bulma/sass/themes";
+@forward "_vendor/bulma/sass/base";
+
+// -----------------------------------------------------------------------------
+// Elements (Only essential elements needed by TouhouFest)
+// -----------------------------------------------------------------------------
+@forward "_vendor/bulma/sass/elements/box";
+@forward "_vendor/bulma/sass/elements/button";
+@forward "_vendor/bulma/sass/elements/container";
+@forward "_vendor/bulma/sass/elements/content";
+@forward "_vendor/bulma/sass/elements/icon";
+@forward "_vendor/bulma/sass/elements/image";
+@forward "_vendor/bulma/sass/elements/notification";
+@forward "_vendor/bulma/sass/elements/progress";
+@forward "_vendor/bulma/sass/elements/table";
+@forward "_vendor/bulma/sass/elements/tag";
+@forward "_vendor/bulma/sass/elements/title";
+@forward "_vendor/bulma/sass/elements/other";
+
+// -----------------------------------------------------------------------------
+// Form (Basic form inputs used for contact and vendor/volunteer signups)
+// -----------------------------------------------------------------------------
+@forward "_vendor/bulma/sass/form";
+
+// -----------------------------------------------------------------------------
+// Components (Selective: ONLY Navbar, Card, and Modal)
+// Stripped: breadcrumb, dropdown, level, media, menu, message, pagination, panel, tabs
+// -----------------------------------------------------------------------------
+@forward "_vendor/bulma/sass/components/card";
+@forward "_vendor/bulma/sass/components/modal";
+@forward "_vendor/bulma/sass/components/navbar";
+
+// -----------------------------------------------------------------------------
+// Grid & Layout
+// -----------------------------------------------------------------------------
+@forward "_vendor/bulma/sass/grid";
+@forward "_vendor/bulma/sass/layout";
+
+// -----------------------------------------------------------------------------
+// Helpers & Utilities
+// -----------------------------------------------------------------------------
+@forward "_vendor/bulma/sass/base/skeleton";
+@forward "_vendor/bulma/sass/helpers";

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -1,0 +1,6 @@
+// =============================================================================
+// Main TouhouFest Stylesheet Entrypoint (Custom SASS Build)
+// Compiles customized Bulma from submodule and custom theme rules.
+// =============================================================================
+
+@use 'bulma-custom';

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,10 +3,7 @@
   <head>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css"
-    >
+    <link rel="stylesheet" href="{{ get_url(path='style.css') }}" />
     <title>{{ config.title }}</title>
     {% include "og_tags.html" %}
   </head>


### PR DESCRIPTION
This PR builds Bulma from a provided a git submodule and strips it down to just the components we need.

Updated the README with cloning instructions.